### PR TITLE
Initial documentation framework

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ sphinx:
   
 python:
   install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt
     - method: pip
       path: .
-      extra_requirements:
-        - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+version: 2
+
+formats: all
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==4.4.0
+sphinx-rtd-theme
+sphinx-sitemap

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,7 +1,7 @@
 .. API Documentation
 
 ********************
-API Documentation!
+API Documentation
 ********************
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,29 @@
+.. API Documentation
+
+********************
+API Documentation!
+********************
+
+
+
+A single page with the entire API reference.
+
+
+notsotuf.client:
+####################
+
+.. automodule:: notsotuf.client     
+
+
+
+notsotuf.repo:
+####################
+
+.. automodule:: notsotuf.repo     
+
+
+notsotuf.common:
+####################
+
+.. automodule:: notsotuf.common     
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,5 +79,5 @@ autodoc_default_options = {
     'inherited-members': True,
 }
 
-html_baseurl = 'https://notsotuf.readthedocs.org'
+html_baseurl = 'https://notsotuf.readthedocs.io'
 html_extra_path = ['robots.txt']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,6 +58,7 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# Settings from the theme. See https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html
 html_theme_options = {
     'display_version': True,
     'prev_next_buttons_location': 'bottom',
@@ -77,5 +78,5 @@ autodoc_default_options = {
     'inherited-members': True,
 }
 
-html_baseurl = 'https://notsotuf.rtd.org'
+html_baseurl = 'https://notsotuf.readthedocs.org'
 html_extra_path = ['robots.txt']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,6 +70,7 @@ html_theme_options = {
     'titles_only': False
 }
 
+# config for autodoc. See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_options
 autodoc_default_options = {
     'members': True,
     'member-order': 'bysource',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,81 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../src/'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'notsotuf'
+copyright = '2022, dennisvang'
+author = 'dennisvang'
+
+# The full version, including alpha/beta/rc tags
+release = '2022.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+"sphinx.ext.autodoc",
+"sphinx.ext.todo",
+"sphinx_sitemap"
+]
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+html_theme_options = {
+    'display_version': True,
+    'prev_next_buttons_location': 'bottom',
+    # Toc options
+    'collapse_navigation': True,
+    'sticky_navigation': True,
+    'navigation_depth': 2,
+	'includehidden': True,
+    'titles_only': False
+}
+
+autodoc_default_options = {
+    'members': True,
+    'member-order': 'bysource',
+    'special-members': '__init__',
+    'undoc-members': False,
+    'inherited-members': True,
+}
+
+html_baseurl = 'https://notsotuf.rtd.org'
+html_extra_path = ['robots.txt']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,12 @@
+Welcome to notsotuf's documentation!
+====================================
+
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   
+   api
+
+

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+
+Sitemap: https://notsotuf.rtd.org/sitemap.xml

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 
-Sitemap: https://notsotuf.rtd.org/sitemap.xml
+Sitemap: https://notsotuf.readthedocs.io/sitemap.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,3 @@ packaging==21.*
 requests
 securesystemslib[crypto,pynacl]==0.22.*
 tuf==1.1.*
-sphinx==4.4.0
-sphinx-rtd-theme
-sphinx-sitemap

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ packaging==21.*
 requests
 securesystemslib[crypto,pynacl]==0.22.*
 tuf==1.1.*
+sphinx==4.4.0
+sphinx-rtd-theme
+sphinx-sitemap


### PR DESCRIPTION
This sets up sphinx, and ReadTheDocs so we can generate documentation, guides and tutorials in the future.

* Example can be [seen here](https://notsotuf.readthedocs.io/en/latest/)
* I'll take the documentation (on the above link from my fork down) once @dennisvang  signs up to rtd and enables the original project


More pages should of course be added in the future, like an installation and getting started page.
But this provides all the boilerplate and configuration

fixes #1 